### PR TITLE
Webpack module rule regex updated for .postcss and .pcss file ext

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export const webpack = (
       rules: [
         ...(webpackConfig.module?.rules ?? []),
         {
-          test: /\.(post)?css$/,
+          test: /\.p?(post)?css$/,
           sideEffects: true,
           ...rule,
           use: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export const webpack = (
       rules: [
         ...(webpackConfig.module?.rules ?? []),
         {
-          test: /\.p?(post)?css$/,
+          test: /\.(p|post)?css$/,
           sideEffects: true,
           ...rule,
           use: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export const webpack = (
       rules: [
         ...(webpackConfig.module?.rules ?? []),
         {
-          test: /\.css$/,
+          test: /\.(post)?css$/,
           sideEffects: true,
           ...rule,
           use: [


### PR DESCRIPTION
Added optional .postcss and .pcss file extension regex. It's still support .css file extension.