### PR TITLE
Refactor webpack rule test to support 'postcss' as a lang/file-extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export const webpack = (
       rules: [
         ...(webpackConfig.module?.rules ?? []),
         {
-          test: /\.css$/,
+          test: /\.(?:post)?css$/,
           sideEffects: true,
           ...rule,
           use: [


### PR DESCRIPTION
[Laravel Mix](https://github.com/laravel-mix/laravel-mix/issues/2211) and [VSCode's Vetur](https://github.com/vuejs/vetur/issues/506) plugin are quite at odds with how to specify that you wish to use PostCSS in your VueJS single-file component. I have used some custom configuration in my project to support `<style lang="postcss">` for my NPM builds, but Storybook (in particular, this postcss addon) does not yet recognise this customisation.

I have updated the css rule test to allow a developer to specify `<style lang="postcss">`  in their single-file components to ensure Vetur and linting tools correctly recognise the code, while still supporting the same compilation when using the default `<style>` element.